### PR TITLE
set default promotion_tier to 2

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -78,8 +78,7 @@ resource "aws_rds_cluster" "this" {
 }
 
 resource "aws_rds_cluster_instance" "this" {
-  count = var.cluster_instance_count
-
+  count                                 = var.cluster_instance_count
   apply_immediately                     = !var.protect
   auto_minor_version_upgrade            = var.auto_minor_version_upgrade
   cluster_identifier                    = aws_rds_cluster.this.id

--- a/variables.tf
+++ b/variables.tf
@@ -341,7 +341,7 @@ variable "protect" {
 variable "promotion_tier" {
   description = "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance#promotion_tier"
   type        = number
-  default     = null
+  default     = 2
 }
 
 variable "replication_source_identifier" {


### PR DESCRIPTION
- Readers in promotion tiers 0 and 1 scale at the same time as the writer.
- Readers in promotion tiers 2–15 scale independently from the writer.